### PR TITLE
Add optional multicallAddress parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ const winners = await computeWinners({
 
 --------------------------------------------------------------------------------
 
+### multicallAddress
+
+Set the `multicallAddress` argument in the input json file to use a custom Multicall contract for RPC calls.
+
+#### Example:
+
+```js
+const winners = await computeWinners({
+  ...,
+  multicallAddress: '0xcA11bde05977b3631167028862bE2a173976CA11' // Gnosis Chiado testnet Multicall3 address
+})
+```
+
+--------------------------------------------------------------------------------
+
 ### blockNumber
 
 The `blockNumber` argument can be set to run the script at a specific block number instead of the current block. Must be either a number or string that can be parsed into a `BigInt`.

--- a/src/prizePool.ts
+++ b/src/prizePool.ts
@@ -4,7 +4,7 @@ import type { Address, ContractFunctionParameters, PublicClient } from "viem"
 export const getPrizePoolInfo = async (
   client: PublicClient,
   prizePoolAddress: Address,
-  options?: { blockNumber?: bigint }
+  options?: { blockNumber?: bigint, multicallAddress?: Address }
 ) => {
   const multicallResults = await client.multicall({
     contracts: [
@@ -30,6 +30,7 @@ export const getPrizePoolInfo = async (
       },
     ],
     blockNumber: options?.blockNumber,
+    multicallAddress: options?.multicallAddress
   })
 
   if (multicallResults.some((i) => i.status === "failure")) {
@@ -62,7 +63,7 @@ export const getTierInfo = async (
   prizePoolAddress: Address,
   numTiers: number,
   lastAwardedDrawId: number,
-  options?: { blockNumber?: bigint }
+  options?: { blockNumber?: bigint, multicallAddress?: Address }
 ) => {
   const tierInfo: {
     [tier: number]: {
@@ -101,6 +102,7 @@ export const getTierInfo = async (
   const firstMulticallResults = await client.multicall({
     contracts: firstContracts,
     blockNumber: options?.blockNumber,
+    multicallAddress: options?.multicallAddress
   })
 
   if (firstMulticallResults.some((i) => i.status === "failure")) {
@@ -125,6 +127,7 @@ export const getTierInfo = async (
   const secondMulticallResults = await client.multicall({
     contracts: secondContracts,
     blockNumber: options?.blockNumber,
+    multicallAddress: options?.multicallAddress
   })
 
   if (secondMulticallResults.some((i) => i.status === "failure")) {

--- a/src/twab.ts
+++ b/src/twab.ts
@@ -7,7 +7,7 @@ export const getTwabs = async (
   vaultAddress: Address,
   userAddresses: Address[],
   timestamps: { start: number, end: number },
-  options?: { blockNumber?: bigint, debug?: boolean }
+  options?: { blockNumber?: bigint, multicallAddress?: Address, debug?: boolean }
 ) => {
   const userTwabs: { address: Address, twab: bigint }[] = []
 
@@ -26,7 +26,8 @@ export const getTwabs = async (
         args: [vaultAddress, userAddress, BigInt(timestamps.start), BigInt(timestamps.end)]
       }))
     ],
-    blockNumber: options?.blockNumber
+    blockNumber: options?.blockNumber,
+    multicallAddress: options?.multicallAddress
   })
 
   if(multicallResults[0].status === 'failure') {


### PR DESCRIPTION
This allows anyone to pass in their own `multicallAddress` Multicall contract address.

I found this helpful when working with Gnosis Chiado, as the version of Viem we were using in this package did not have an address for a Multicall contract on this chain.